### PR TITLE
Add missing Server type export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 import EventEmitter, { EventMap } from 'bare-events'
 import { Duplex, DuplexEvents } from 'bare-stream'
+import PipeError from './lib/errors'
+import constants from './lib/constants'
 
 interface PipeEvents extends DuplexEvents {
   connect: []
@@ -93,65 +95,44 @@ declare class PipeServer<
   constructor(onconnection: () => void)
 }
 
-interface CreateConnectionOptions extends PipeOptions, PipeConnectOptions {}
-
-declare function createConnection(
-  path: string,
-  opts?: CreateConnectionOptions,
-  onconnect?: () => void
-): Pipe
-
-declare function createConnection(path: string, onconnect: () => void): Pipe
-
-declare function createConnection(
-  opts: CreateConnectionOptions,
-  onconnect?: () => void
-): Pipe
-
-declare function createServer(
-  opts?: PipeServerOptions,
-  onconnection?: () => void
-): PipeServer
-
-declare function pipe(): [read: number, write: number]
-
-declare const constants: {
-  CONNECTING: number
-  CONNECTED: number
-  BINDING: number
-  BOUND: number
-  READING: number
-  CLOSING: number
-  READABLE: number
-  WRITABLE: number
-}
-
-declare class PipeError extends Error {
-  static PIPE_ALREADY_CONNECTED(msg: string): PipeError
-  static SERVER_ALREADY_LISTENING(msg: string): PipeError
-  static SERVER_IS_CLOSED(msg: string): PipeError
-}
-
 declare namespace Pipe {
-  export {
-    Pipe,
-    pipe,
-    PipeServer as Server,
-    constants,
-    PipeError as errors,
-    createConnection,
-    createServer
-  }
+  export interface CreateConnectionOptions
+    extends PipeOptions,
+      PipeConnectOptions {}
 
-  export type {
-    PipeEvents,
-    PipeOptions,
-    PipeConnectOptions,
-    PipeServerEvents,
-    PipeServerOptions,
-    PipeServerListenOptions,
-    PipeServer,
-    CreateConnectionOptions
+  export function createConnection(
+    path: string,
+    opts?: CreateConnectionOptions,
+    onconnect?: () => void
+  ): Pipe
+
+  export function createConnection(path: string, onconnect: () => void): Pipe
+
+  export function createConnection(
+    opts: CreateConnectionOptions,
+    onconnect?: () => void
+  ): Pipe
+
+  export function createServer(
+    opts?: PipeServerOptions,
+    onconnection?: () => void
+  ): PipeServer
+
+  export function pipe(): [read: number, write: number]
+
+  export {
+    type PipeEvents,
+    type PipeOptions,
+    Pipe,
+    type PipeConnectOptions,
+    type PipeServerEvents,
+    type PipeServerOptions,
+    type PipeServerListenOptions,
+    type PipeServer,
+    PipeServer as Server,
+    type PipeError,
+    PipeError as errors,
+    constants
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,24 +42,24 @@ declare class Pipe<M extends PipeEvents = PipeEvents> extends Duplex<M> {
   constructor(opts?: PipeOptions)
 }
 
-interface ServerEvents extends EventMap {
+interface PipeServerEvents extends EventMap {
   close: []
   connection: [pipe: Pipe]
   err: [err: Error]
   listening: []
 }
 
-interface ServerOptions {
+interface PipeServerOptions {
   readBufferSize?: number
   allowHalfOpen?: boolean
 }
 
-interface ServerListenOptions {
+interface PipeServerListenOptions {
   path?: string
   backlog?: number
 }
 
-interface Server<M extends ServerEvents = ServerEvents>
+interface PipeServer<M extends PipeServerEvents = PipeServerEvents>
   extends EventEmitter<M> {
   readonly listening: boolean
 
@@ -68,7 +68,7 @@ interface Server<M extends ServerEvents = ServerEvents>
   listen(
     path: string,
     backlog?: number,
-    opts?: ServerListenOptions,
+    opts?: PipeServerListenOptions,
     onlistening?: () => void
   ): this
 
@@ -76,7 +76,7 @@ interface Server<M extends ServerEvents = ServerEvents>
 
   listen(path: string, onlistening: () => void): this
 
-  listen(opts: ServerListenOptions): this
+  listen(opts: PipeServerListenOptions): this
 
   close(onclose?: () => void): void
 
@@ -85,12 +85,45 @@ interface Server<M extends ServerEvents = ServerEvents>
   unref(): void
 }
 
-declare class Server<
-  M extends ServerEvents = ServerEvents
+declare class PipeServer<
+  M extends PipeServerEvents = PipeServerEvents
 > extends EventEmitter<M> {
-  constructor(opts?: ServerOptions, onconnection?: () => void)
+  constructor(opts?: PipeServerOptions, onconnection?: () => void)
 
   constructor(onconnection: () => void)
+}
+
+interface CreateConnectionOptions extends PipeOptions, PipeConnectOptions {}
+
+declare function createConnection(
+  path: string,
+  opts?: CreateConnectionOptions,
+  onconnect?: () => void
+): Pipe
+
+declare function createConnection(path: string, onconnect: () => void): Pipe
+
+declare function createConnection(
+  opts: CreateConnectionOptions,
+  onconnect?: () => void
+): Pipe
+
+declare function createServer(
+  opts?: PipeServerOptions,
+  onconnection?: () => void
+): PipeServer
+
+declare function pipe(): [read: number, write: number]
+
+declare const constants: {
+  CONNECTING: number
+  CONNECTED: number
+  BINDING: number
+  BOUND: number
+  READING: number
+  CLOSING: number
+  READABLE: number
+  WRITABLE: number
 }
 
 declare class PipeError extends Error {
@@ -100,49 +133,25 @@ declare class PipeError extends Error {
 }
 
 declare namespace Pipe {
-  export interface CreateConnectionOptions
-    extends PipeOptions,
-      PipeConnectOptions {}
-
-  export function createConnection(
-    path: string,
-    opts?: CreateConnectionOptions,
-    onconnect?: () => void
-  ): Pipe
-
-  export function createConnection(path: string, onconnect: () => void): Pipe
-
-  export function createConnection(
-    opts: CreateConnectionOptions,
-    onconnect?: () => void
-  ): Pipe
-
-  export function createServer(
-    opts?: ServerOptions,
-    onconnection?: () => void
-  ): Server
-
-  export function pipe(): [read: number, write: number]
-
-  export const constants: {
-    CONNECTING: number
-    CONNECTED: number
-    BINDING: number
-    BOUND: number
-    READING: number
-    CLOSING: number
-    READABLE: number
-    WRITABLE: number
-  }
-
   export {
     Pipe,
+    pipe,
+    PipeServer as Server,
+    constants,
+    PipeError as errors,
+    createConnection,
+    createServer
+  }
+
+  export type {
     PipeEvents,
     PipeOptions,
     PipeConnectOptions,
-    PipeError as errors,
-    ServerEvents,
-    ServerOptions
+    PipeServerEvents,
+    PipeServerOptions,
+    PipeServerListenOptions,
+    PipeServer,
+    CreateConnectionOptions
   }
 }
 

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,0 +1,12 @@
+declare const constants: {
+  CONNECTING: number
+  CONNECTED: number
+  BINDING: number
+  BOUND: number
+  READING: number
+  CLOSING: number
+  READABLE: number
+  WRITABLE: number
+}
+
+export = constants

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -1,0 +1,7 @@
+declare class PipeError extends Error {
+  static PIPE_ALREADY_CONNECTED(msg: string): PipeError
+  static SERVER_ALREADY_LISTENING(msg: string): PipeError
+  static SERVER_IS_CLOSED(msg: string): PipeError
+}
+
+export = PipeError

--- a/package.json
+++ b/package.json
@@ -3,13 +3,19 @@
   "version": "4.0.3",
   "description": "Native I/O pipes for JavaScript",
   "exports": {
+    "./package": "./package.json",
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
     },
-    "./package": "./package.json",
-    "./constants": "./lib/constants.js",
-    "./errors": "./lib/errors.js"
+    "./constants": {
+      "types": "./lib/constants.d.ts",
+      "default": "./lib/constants.js"
+    },
+    "./errors": {
+      "types": "./lib/errors.d.ts",
+      "default": "./lib/errors.js"
+    }
   },
   "files": [
     "index.js",


### PR DESCRIPTION
The export `PipeServer as Server,` was missing.

Added `Pipe` prefix to some types.
And also an attempt to organize better the `export` section.