### PR TITLE
Add `eagerOpen` to Pipe constructor options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,9 @@ interface PipeEvents extends DuplexEvents {
 }
 
 interface PipeOptions {
-  readBufferSize?: number
   allowHalfOpen?: boolean
+  eagerOpen?: boolean
+  readBufferSize?: number
 }
 
 interface PipeConnectOptions {

--- a/index.js
+++ b/index.js
@@ -9,15 +9,18 @@ const defaultReadBufferSize = 65536
 
 module.exports = exports = class Pipe extends Duplex {
   constructor(path, opts = {}) {
-    super({ eagerOpen: true })
-
     if (typeof path === 'object' && path !== null) {
       opts = path
       path = null
     }
 
-    const { readBufferSize = defaultReadBufferSize, allowHalfOpen = true } =
-      opts
+    const {
+      allowHalfOpen = true,
+      eagerOpen = true,
+      readBufferSize = defaultReadBufferSize
+    } = opts
+
+    super({ eagerOpen })
 
     this._state = 0
 


### PR DESCRIPTION
I've chosen to maintain the original value for backward compatibility.